### PR TITLE
Calling typed('reset') works for text inputs

### DIFF
--- a/js/typed.js
+++ b/js/typed.js
@@ -278,8 +278,15 @@
             , reset: function(){
                 var self = this;
                 clearInterval(self.timeout);
-                var id = this.el.attr('id');
-                this.el.after('<span id="' + id + '"/>')
+
+                if(this.isInput) {
+                    var name = this.el.attr('name');
+                    this.el.after('<input name="' + name + '" type="text">');
+                } else {
+                    var id = this.el.attr('id');
+                    this.el.after('<span id="' + id + '"/>');
+                }
+
                 this.el.remove();
                 this.cursor.remove();
                 // Send the callback


### PR DESCRIPTION
Not sure if this is useful to anyone, found an issue in the plugin where calling `typed('reset')` in an `input` element didn't behave as desired (as it'd insert a span rather than the original element type).

Thanks for the plugin, I hope my hack contributes.
