### PR TITLE
Patch: if no cursor were present, the reset function would throw an erro...

### DIFF
--- a/js/typed.js
+++ b/js/typed.js
@@ -324,7 +324,9 @@
             var id = this.el.attr('id');
             this.el.after('<span id="' + id + '"/>')
             this.el.remove();
-            this.cursor.remove();
+            if (typeof this.cursor !== 'undefined') {
+                this.cursor.remove();
+            }
             // Send the callback
             self.options.resetCallback();
         }


### PR DESCRIPTION
If the plugin is initialized with the option `showCursor: false`, no "cursor" property is created.
Calling the reset function (`typed('reset')`) after that throws an error, because of a missing check if the cursor exists at all.