### PR TITLE
added required info for npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,16 @@
 {
+  "name": "typed.js",
+  "version": "1.1.0",
+  "homepage": "https://github.com/mattboldt/typed.js",
+  "authors": [
+    "Matt Boldt <me@mattboldt.com>"
+  ],
+  "description": "A jQuery typing animation script",
+  "main": "js/typed.js",
+  "keywords": [
+    "typed",
+    "animation"
+  ],
   "devDependencies": {
     "gulp": "^3.8.10",
     "gulp-rename": "^1.2.0",


### PR DESCRIPTION
I added the required info in the package.json so now you can install typed.js with npm as well:

npm install mattboldt/typed.js --save-dev

that will work if you accept the pull request, currently you get an error.