### PR TITLE
Method skip

### DIFF
--- a/js/typed.js
+++ b/js/typed.js
@@ -43,7 +43,7 @@
         this.showCursor = this.isInput ? false : this.options.showCursor;
 
         // text content of element
-        this.elContent = this.attr ? this.el.attr(this.attr) : this.el.text()
+        this.elContent = this.attr ? this.el.attr(this.attr) : this.el.text();
 
         // html or plain text
         this.contentType = this.options.contentType;
@@ -341,6 +341,13 @@
             // Send the callback
             self.options.resetCallback();
         }
+        ,
+        // Skip the typing effect
+        skip: function() {
+            var self = this;            
+            clearInterval(self.timeout);			
+            self.typewrite(self.strings[self.arrayPos], self.strings[self.arrayPos].length - 1);
+		}
 
     };
 

--- a/js/typed.js
+++ b/js/typed.js
@@ -347,7 +347,7 @@
             var self = this;            
             clearInterval(self.timeout);			
             self.typewrite(self.strings[self.arrayPos], self.strings[self.arrayPos].length - 1);
-		}
+        }
 
     };
 


### PR DESCRIPTION
Skip the typing animation
A method that skips the animation and shows the whole text typed. I use your plugin to show popups, so this method helps users to skip the animation and read the whole text.
