### PR TITLE
added options "findStopNum"

### DIFF
--- a/js/typed.js
+++ b/js/typed.js
@@ -63,6 +63,9 @@
         // input strings of text
         this.strings = this.options.strings;
 
+        // automatically find stopNum
+        this.findStopNum = this.options.findStopNum;
+
         // character number position of current string
         this.strPos = 0;
 
@@ -282,6 +285,23 @@
                 // ----- continue important stuff ----- //
                 // replace text with base text + typed characters
                 var nextString = curString.substr(0, curStrPos);
+                
+                // Find self.stopNum automatically if the current string matches the first characters of the next string
+                if ( self.findStopNum ) {
+                    var nextArrayPos = self.arrayPos + 1;
+                    if ( nextArrayPos >= self.strings.length ) {
+                        nextArrayPos = 0;
+                    }
+
+                    if ( nextString == self.strings[ nextArrayPos ].substr(0, curStrPos) ) {
+                        self.stopNum = curStrPos;
+                        self.strPos = curStrPos;
+                    } else {
+                        self.stopNum = 0;
+                    }
+                }
+
+
                 if (self.attr) {
                     self.el.attr(self.attr, nextString);
                 } else {
@@ -407,6 +427,8 @@
         attr: null,
         // either html or text
         contentType: 'html',
+        // automatically find stopNum
+        findStopNum: true,
         // call when done callback function
         callback: function() {},
         // starting callback function before each string


### PR DESCRIPTION
In addition to the hardcoded (commented out) script that stops the backspace method from removing the first word (lines 259 to 270), this option makes the backspace method automatically detect whether the next sentence starts with the same characters as currently typed.

In this example, the backspace method will not remove "Typed.js ", instead it will continue typing with the next sentence:
````javascript
$("#foo").typed({
    strings: [
        "Typed.js is a jQuery plugin",
        "Typed.js types out text"
    ]
});
````

Cool script by the way :)