### PR TITLE
UPDATE - Strings from static HTML

### DIFF
--- a/js/typed.js
+++ b/js/typed.js
@@ -128,9 +128,9 @@
             if (this.stringsElement) {
                 self.strings = [];
                 this.stringsElement.hide();
-                var strings = this.stringsElement.find('p');
+                var strings = this.stringsElement.children();
                 $.each(strings, function(key, value){
-                    self.strings.push($(value).html());
+                    self.strings.push(value.outerHTML);
                 });
             }
             this.init();


### PR DESCRIPTION
We can wrap other elementt except for the `p` in `div` :tada:

Example:
```html
<script>
    $(function(){
        $("#typed").typed({
            stringsElement: $('#typed-strings')
        });
    });
</script>
```
**Now, we can wrap other element.**
```html
<div id="typed-strings">
    <p>Typed.js is a <strong>jQuery</strong> plugin.</p>
    <p>It <em>types</em> out sentences.</p>
    <h1>h1 sentence here.</h1>
    <span>
        Typed.js is awsome
        <i class="fa fa-heart"></i>
    </span>
</div>
<span id="typed"></span>
```

Please, merge it, thx :smiley: 