### PR TITLE
Trim whitespace

### DIFF
--- a/js/typed.js
+++ b/js/typed.js
@@ -413,7 +413,7 @@
         // shuffle the strings
         shuffle: false,
         // time before backspacing
-        backDelay: 3000,
+        backDelay: 500,
         // loop
         loop: false,
         // false = infinite

--- a/js/typed.js
+++ b/js/typed.js
@@ -66,6 +66,9 @@
         // input strings of text
         this.strings = this.options.strings;
 
+        // whether we should strip whitespace around the strings
+        this.trimStrings = this.options.trimStrings;
+
         // character number position of current string
         this.strPos = 0;
 
@@ -132,6 +135,9 @@
                 $.each(strings, function(key, value){
                     self.strings.push($(value).html());
                 });
+            }
+            if (this.trimStrings) {
+                self.strings = self.strings.map(function(s){return s.trim()});
             }
             this.init();
         }
@@ -407,7 +413,7 @@
         // shuffle the strings
         shuffle: false,
         // time before backspacing
-        backDelay: 500,
+        backDelay: 3000,
         // loop
         loop: false,
         // false = infinite


### PR DESCRIPTION
If you are using a template engine that automatically pretty-prints your HTML, the extra whitespace can throw off typed.js. This tiny tweak allows you to trim your strings if needed.
