### PR TITLE
please review typed cursor is created using id not class

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ bower install typed.js
 Want the animated blinking cursor? Add this CSS.
 
 ~~~ scss
-.typed-cursor{
+#typed-cursor{
 	opacity: 1;
 	-webkit-animation: blink 0.7s infinite;
 	-moz-animation: blink 0.7s infinite;


### PR DESCRIPTION
in document model typed cursor is created using id not the class that's why i corrected that. This Happen particularly in the case of copying the css,(generated markups are different)