### PR TITLE
Toggle backspace on/off

### DIFF
--- a/js/typed.js
+++ b/js/typed.js
@@ -53,6 +53,9 @@
 
 		// add a delay before typing starts
 		this.startDelay = this.options.startDelay;
+		
+		// toggle backspacing on/off (= true/false)
+		this.backspacing = this.options.backspacing;
 
 		// backspacing speed
 		this.backSpeed = this.options.backSpeed;
@@ -254,6 +257,11 @@
 		},
 
 		backspace: function(curString, curStrPos) {
+			// jump to next string if backspacing is off
+			if (!this.backspacing) {
+				curStrPos = 0;
+			}
+			
 			// exit when stopped
 			if (this.stop === true) {
 				return;
@@ -406,6 +414,8 @@
 		typeSpeed: 0,
 		// time before typing starts
 		startDelay: 0,
+		// toggle backspacing on/off (= true/false)
+		backspacing: true,
 		// backspacing speed
 		backSpeed: 0,
 		// shuffle the strings


### PR DESCRIPTION
This change will leave an option for user to toggle the backspacing functionality. Not everyone wants their clients to wait and watch a bunch of strings rolling back ... when there are a bunch of strings and long sentences to roll back.

I am too much swamped with other tasks to checkout a branch in local dev. env. (doing this pull from a web), as I currently don't have node.js on this machine, so I'm sorry for not doing the legit pull request with a gulp build (hence no minified typed.js of this proposed change) ... this is a small change so it can at least serve as a hint to someone else.
