### PR TITLE
Stop blinking whilst typing

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,22 +38,28 @@ bower install typed.js
 Want the animated blinking cursor? Add this CSS.
 
 ~~~ scss
-.typed-cursor{
+.typed-cursor {
 	opacity: 1;
-	-webkit-animation: blink 0.7s infinite;
-	-moz-animation: blink 0.7s infinite;
-	animation: blink 0.7s infinite;
+	
+	&.is-paused {
+		-webkit-animation: blink 0.7s infinite;
+		-moz-animation: blink 0.7s infinite;
+		animation: blink 0.7s infinite;
+	}
 }
+
 @keyframes blink{
 	0% { opacity:1; }
 	50% { opacity:0; }
 	100% { opacity:1; }
 }
+
 @-webkit-keyframes blink{
 	0% { opacity:1; }
 	50% { opacity:0; }
 	100% { opacity:1; }
 }
+
 @-moz-keyframes blink{
 	0% { opacity:1; }
 	50% { opacity:0; }

--- a/js/typed.js
+++ b/js/typed.js
@@ -137,6 +137,10 @@
 
 		// pass current string state to each function, types 1 char per call
 		typewrite: function(curString, curStrPos) {
+			// Stops blinking while typing
+			var tmpcursor = document.getElementsByClassName("typed-cursor")[0];
+			tmpcursor.className = tmpcursor.className.replace(new RegExp('(?:^|\\s)'+ 'is-animated' + '(?:\\s|$)'), '');
+
 			// exit when stopped
 			if (this.stop === true) {
 				return;
@@ -199,6 +203,10 @@
 				// timeout for any pause after a character
 				self.timeout = setTimeout(function() {
 					if (curStrPos === curString.length) {
+						// Resume blinking when typing stops
+						var tmpcursor = document.getElementsByClassName("typed-cursor")[0];
+						tmpcursor.className += " is-animated";
+						
 						// fires callback function
 						self.options.onStringTyped(self.arrayPos);
 
@@ -254,6 +262,10 @@
 		},
 
 		backspace: function(curString, curStrPos) {
+			// Stops blinking when backspacing
+			var tmpcursor = document.getElementsByClassName("typed-cursor")[0];
+			tmpcursor.className = tmpcursor.className.replace(new RegExp('(?:^|\\s)'+ 'is-animated' + '(?:\\s|$)'), '');
+
 			// exit when stopped
 			if (this.stop === true) {
 				return;

--- a/js/typed.js
+++ b/js/typed.js
@@ -139,7 +139,7 @@
 		typewrite: function(curString, curStrPos) {
 			// Stops blinking while typing
 			var tmpcursor = document.getElementsByClassName("typed-cursor")[0];
-			tmpcursor.className = tmpcursor.className.replace(new RegExp('(?:^|\\s)'+ 'is-animated' + '(?:\\s|$)'), '');
+			tmpcursor.className = tmpcursor.className.replace(new RegExp('(?:^|\\s)'+ 'is-paused' + '(?:\\s|$)'), '');
 
 			// exit when stopped
 			if (this.stop === true) {
@@ -205,7 +205,7 @@
 					if (curStrPos === curString.length) {
 						// Resume blinking when typing stops
 						var tmpcursor = document.getElementsByClassName("typed-cursor")[0];
-						tmpcursor.className += " is-animated";
+						tmpcursor.className += " is-paused";
 						
 						// fires callback function
 						self.options.onStringTyped(self.arrayPos);
@@ -264,7 +264,7 @@
 		backspace: function(curString, curStrPos) {
 			// Stops blinking when backspacing
 			var tmpcursor = document.getElementsByClassName("typed-cursor")[0];
-			tmpcursor.className = tmpcursor.className.replace(new RegExp('(?:^|\\s)'+ 'is-animated' + '(?:\\s|$)'), '');
+			tmpcursor.className = tmpcursor.className.replace(new RegExp('(?:^|\\s)'+ 'is-paused' + '(?:\\s|$)'), '');
 
 			// exit when stopped
 			if (this.stop === true) {


### PR DESCRIPTION
Solves issue https://github.com/mattboldt/typed.js/issues/179

This based on the work from https://github.com/djcaesar9114 in https://github.com/mattboldt/typed.js/pull/180.

Pausing the animation was causing an issue that sometimes the paused state would be when the cursor is not visible, leading the backspace and typing actions to have no cursor at all.

This one just adds and removes a class when the typewriter has stopped typing, which we can trigger the animation from.