### PR TITLE
Changed main to point to non uglified file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "Matt Boldt <me@mattboldt.com>"
   ],
   "description": "A jQuery typing animation script",
-  "main": "dist/typed.min.js",
+  "main": "js/typed.js",
   "keywords": [
     "typed",
     "animation"


### PR DESCRIPTION
Bower reports an error when installing that the main field cannot point to a minified file.
Bower Notice:
bower typed.js#*          invalid-meta The "main" field cannot contain minified files