### PR TITLE
Removed obsolete website example from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,6 @@ https://www.typed.com/
 
 https://git.market/
 
-http://allison.house/404
-
 http://www.maxcdn.com/
 
 https://commando.io/


### PR DESCRIPTION
Removed alison.house/404 because:

- page doesn’t exist anymore.
- alison.house redirects to a website not using typed.js