### PR TITLE
prevent mixed content errors

### DIFF
--- a/assets/demos.css
+++ b/assets/demos.css
@@ -1,4 +1,4 @@
-@import url(http://fonts.googleapis.com/css?family=Ubuntu:400,500);
+@import url(https://fonts.googleapis.com/css?family=Ubuntu:400,500);
 
 *{
 	padding:0;


### PR DESCRIPTION
Loading demo.css on a https site (e.g. https://jsfiddle.net/) fails to load the font since it's imported over http.