### PR TITLE
Fix element mismatch in static HTML example

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ This allows bots and search engines, as well as users with JavaScript disabled, 
 
 ~~~ javascript
 <script>
-  var typed = new Typed('.element', {
+  var typed = new Typed('#typed', {
     stringsElement: '#typed-strings'
   });
 </script>


### PR DESCRIPTION
Matched selector used in HTML to that used in JavaScript, to avoid confusion (example code doesn't work otherwise).

### Requirements

<!--
Filling out this template is required.
-->

 - [x] Have you viewed your changes locally on the demos page, located on https://github.com/mattboldt/typed.js/blob/master/index.html?

 - [x] If necessary, have you added a new demo to the index.html list of demos? If it's an improvement or small addition, have you added it to an existing demo on the demos page?

 - [x] If applicable, have you created a fork of the following JSFiddle with your branch's code and your new feature showcased?

<!--

    To include your branch's version of Typed.js, simply add this JavaScript url as a dependency in JSFiddle, and remove the default:

    https://jsfiddle.net/mattboldt/1xs3LLmL/

    ```
    https://rawgit.com/<YOUR GITHUB USERNAME>/typed.js/<YOUR BRANCH NAME>/lib/typed.min.js
    ```
-->

### Description of the Change

Very small documentation update to one of the examples.

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.

-->

### Benefits

Documentation for static HTML usage easier to understand.

<!-- What benefits will be realized by the code change? -->

### Issues

No issue number, just something I picked up on while I was trying it out.

<!-- Enter any applicable Issues here -->
