### PR TITLE
Update Typescript Definition file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -48,7 +48,7 @@ declare module 'typed.js' {
     /**
      * Fade out delay in milliseconds
      */
-    fadeOutDelay?: boolean;
+    fadeOutDelay?: number;
     /**
      * loop strings
      */


### PR DESCRIPTION
### Description of the Change

Update Typescript definition to match what the JavaScript code expects. Specifically update the `fadeOutDelay` option to `number` rather then `boolean` to reflect how it is intended to be used. For example in [`src/defaults.js`](https://github.com/mattboldt/typed.js/blob/master/src/defaults.js#L52) it defaults to the `number` 500

### Benefits

Improves autocomplete in Visual Studio Code for everyone and fixes bug where Typescript will fail to build if a number is passed to `fadeOutDelay`