### PR TITLE
[TypeScript] Change constructor to also accept an element as the first argument

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -124,7 +124,7 @@ declare module 'typed.js' {
   }
 
   export default class Typed {
-    constructor(elementId: string, options: TypedOptions);
+    constructor(elementId: string | Element, options: TypedOptions);
     toggle(): void;
     stop(): void;
     start(): void;


### PR DESCRIPTION
### Requirements

<!--
Filling out this template is required.
-->

 - [x] Have you viewed your changes locally on the demos page, located on https://github.com/mattboldt/typed.js/blob/master/index.html?

 - [ ] ~If necessary, have you added a new demo to the index.html list of demos? If it's an improvement or small addition, have you added it to an existing demo on the demos page?~

 - [ ] ~If applicable, have you created a fork of the following JSFiddle with your branch's code and your new feature showcased?~

<!--

    To include your branch's version of Typed.js, simply add this JavaScript url as a dependency in JSFiddle, and remove the default:

    https://jsfiddle.net/mattboldt/1xs3LLmL/

    ```
    https://rawgit.com/<YOUR GITHUB USERNAME>/typed.js/<YOUR BRANCH NAME>/lib/typed.min.js
    ```
-->

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.

-->

### Benefits

Consumers of this library that are also using typescript can correctly pass an element as a first argument to the constructor.

https://github.com/mattboldt/typed.js/blob/master/src/initializer.js#L17-L21

### Issues

Feature was added in https://github.com/mattboldt/typed.js/pull/268
