### PR TITLE
Fix missing type for stringsElement option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,9 +10,9 @@ declare module 'typed.js' {
      */
     strings?: string[];
     /**
-     * ID of element containing string children
+     * ID or instance of HTML element of element containing string children
      */
-    stringsElement?: string;
+    stringsElement?: string | Element;
     /**
      * type speed in milliseconds
      */


### PR DESCRIPTION
### Requirements

<!--
Filling out this template is required.
-->

 - [x] Have you viewed your changes locally on the demos page, located on https://github.com/mattboldt/typed.js/blob/master/index.html?

 - ~~[ ] If necessary, have you added a new demo to the index.html list of demos? If it's an improvement or small addition, have you added it to an existing demo on the demos page?~~

 - ~~[ ] If applicable, have you created a fork of the following JSFiddle with your branch's code and your new feature showcased?~~

<!--

    To include your branch's version of Typed.js, simply add this JavaScript url as a dependency in JSFiddle, and remove the default:

    https://jsfiddle.net/mattboldt/1xs3LLmL/

    ```
    https://rawgit.com/<YOUR GITHUB USERNAME>/typed.js/<YOUR BRANCH NAME>/lib/typed.min.js
    ```
-->

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.

-->

Fix missing TypeScript type for stringsElement option.

https://github.com/mattboldt/typed.js/pull/268/files#diff-00d21e199acf486204adf53fb93c4249R646-R650

### Benefits

<!-- What benefits will be realized by the code change? -->

### Issues

<!-- Enter any applicable Issues here -->

#268, #436