### PR TITLE
cursor using `user-select: none`

### DIFF
--- a/src/initializer.js
+++ b/src/initializer.js
@@ -171,6 +171,7 @@ export default class Initializer {
     css.innerHTML = `
         .typed-cursor{
           opacity: 1;
+          user-select: none;
         }
         .typed-cursor.typed-cursor--blink{
           animation: typedjsBlink 0.7s infinite;


### PR DESCRIPTION
### Requirements

 - [x] Have you viewed your changes locally on the demos page, located on https://github.com/mattboldt/typed.js/blob/master/index.html?

 - [ ] If necessary, have you added a new demo to the index.html list of demos? If it's an improvement or small addition, have you added it to an existing demo on the demos page?

 - [x] If applicable, have you created a fork of the following JSFiddle with your branch's code and your new feature showcased?
     > https://jsfiddle.net/wiidede/bLphqrc2/2/

### Description of the Change

I think the cursor should add `user-select: none`. Otherwise the cursor `|` will be selected easily while I want to select the whole sentence.

### Benefits

`|` cannot be selected

### Issues

None
